### PR TITLE
Unexport the lru_cache module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+The 0.5 version will bring a bunch of breaking changes to sanitize the API
+and pave the way towards a stable 1.0.
+
+### Removed
+- The `lru_cache` module is not exported anymore, to allow swapping the
+internal LRU logic in a future release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@
 
 #[macro_use]
 extern crate log;
-//extern crate lru_cache;
-pub mod lru_cache;
 
+mod lru_cache;
+
+use crate::lru_cache::{LruCache, Meter};
+use filetime::{set_file_times, FileTime};
 use std::borrow::Borrow;
 use std::boxed::Box;
 use std::collections::hash_map::RandomState;
@@ -16,9 +18,6 @@ use std::hash::BuildHasher;
 use std::io;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
-
-pub use crate::lru_cache::{LruCache, Meter};
-use filetime::{set_file_times, FileTime};
 use walkdir::WalkDir;
 
 struct FileSize;


### PR DESCRIPTION
### See #1 for more context

We might eventually want to swap this logic for an off-the-shelf in-memory LRU crate. In the meantime, unexport it, to allow doing so without it being a breaking change.